### PR TITLE
Account for folds and don't call redraw

### DIFF
--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -336,6 +336,7 @@ endfunction
 " *************************************************
 " * Main (entry points)
 " *************************************************
+
 function! scrollview#RemoveBars() abort
   let l:state = s:Init()
   try

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -48,6 +48,10 @@ function! s:WinExecute(winid, commands) abort
   endif
 endfunction
 
+function! s:NumberToFloat(number) abort
+  return a:number + 0.0
+endfunction
+
 " *************************************************
 " * Core
 " *************************************************
@@ -207,7 +211,7 @@ function! s:CalculatePosition(winnr) abort
     if l:mode ==# 'document'
       let l:numerator = l:botline - l:topline + 1
     endif
-    let l:height = str2float(l:numerator) / l:line_count
+    let l:height = s:NumberToFloat(l:numerator) / l:line_count
     let l:height = float2nr(ceil(l:height * l:winheight))
   endif
   " Make sure bar properly reflects bottom of document.

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -62,7 +62,7 @@ endfunction
 " Returns true for ordinary windows (not floating and not external), and
 " false otherwise.
 function! s:IsOrdinaryWindow(winid) abort
-  let l:config = nvim_win_get_config(win_getid(a:winid))
+  let l:config = nvim_win_get_config(a:winid)
   let l:not_external = !get(l:config, 'external', 0)
   let l:not_floating = get(l:config, 'relative', '') ==# ''
   return l:not_external && l:not_floating
@@ -254,9 +254,9 @@ function! s:CalculatePosition(winnr) abort
   return l:result
 endfunction
 
-function! s:ShowScrollbar(winnr) abort
-  let l:winnr = a:winnr
-  let l:winid = win_getid(l:winnr)
+function! s:ShowScrollbar(winid) abort
+  let l:winid = a:winid
+  let l:winnr = win_id2win(l:winid)
   let l:bufnr = winbufnr(l:winnr)
   let l:buf_filetype = getbufvar(l:bufnr, '&l:filetype', '')
   let l:winheight = winheight(l:winnr)
@@ -351,16 +351,17 @@ function! scrollview#RefreshBars() abort
     let l:current_only =
           \ s:GetVariable('scrollview_current_only', winnr(), 'tg')
     if l:current_only
-      call add(l:target_wins, winnr())
+      call add(l:target_wins, win_getid(winnr()))
     else
-      for l:winid in range(1, winnr('$'))
+      for l:winnr in range(1, winnr('$'))
+        let l:winid = win_getid(l:winnr)
         if s:IsOrdinaryWindow(l:winid)
           call add(l:target_wins, l:winid)
         endif
       endfor
     endif
-    for l:winnr in l:target_wins
-      call s:ShowScrollbar(l:winnr)
+    for l:winid in l:target_wins
+      call s:ShowScrollbar(l:winid)
     endfor
     " Redraw to prevent flickering (which occurred when there were folds, but
     " not otherwise).

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -329,8 +329,8 @@ function! s:Init()
         \   'winwidth': &winwidth,
         \   'winheight': &winheight
         \ }
-  " Minimize winwidth and winheight so that moving around doesn't unexpectedly
-  " cause window resizing.
+  " Minimize winwidth and winheight so that changing the current window
+  " doesn't unexpectedly cause window resizing.
   set eventignore=all
   let &winwidth = max([1, &winminwidth])
   let &winheight = max([1, &winminheight])

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -143,6 +143,34 @@ function! s:GetVariable(name, winnr, ...) abort
   return l:default
 endfunction
 
+" Returns the count of visible lines between (inclusive) the specified start
+" and end lines, in the current window. A closed fold counts as one visible
+" line.
+" TODO: Port to Lua to execute faster, or alternatively use Vim's built-in
+" fold movement commands to figure out the count of visible lines.
+function! s:VisibleLineCount(start, end) abort
+  let l:result = 0
+  let l:line = a:start
+  while l:line <=# a:end
+    let l:result += 1
+    let l:foldclosedend = foldclosedend(l:line)
+    if l:foldclosedend !=# -1
+      let l:line = l:foldclosedend
+    endif
+    let l:line += 1
+  endwhile
+  return l:result
+endfunction
+
+" Same as VisibleLineCount, but operates on the specified window, as opposed
+" to the current window.
+function! s:WinVisibleLineCount(winid, start, end) abort
+  let l:command =
+        \ 'let l:result = s:VisibleLineCount(' . a:start . ', ' . a:end . ')'
+  let l:result = s:WinExecute(a:winid, [l:command])
+  return l:result
+endfunction
+
 " Calculates the bar position for the specified window. Returns a dictionary
 " with a height, row, and col.
 function! s:CalculatePosition(winnr) abort

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -50,7 +50,7 @@ have the highest precedence, and global variables have the lowest).
 *scrollview_on_startup*                   `1`
   Specifies whether scrollbars are        Considered only at global scope
   enabled on startup
-*scrollview_mode*                         `'default'`
+*scrollview_mode*                         `'simple'`
   Specifies what the scrollbar            See |scrollview-modes| for details on
   position and size correspond to         the available modes
 *scrollview_excluded_filetypes*           `[]`
@@ -88,7 +88,7 @@ setting (set as a |string|).
 
 Mode       Description
 ----       -----------
-*default*    The scrollbar top position reflects the window's top line number
+*simple*     The scrollbar top position reflects the window's top line number
            relative to the document's line count. The scrollbar height reflects
            the size of the window relative to the document's line count.
 
@@ -100,7 +100,7 @@ Mode       Description
            relative to the document's line count.
 
 *virtual*    The scrollbar position and height are calculated similarly to
-           the |default| mode, but line numbers and the document line count
+           the |simple| mode, but line numbers and the document line count
            are implicitly updated to virtual counterparts that account for
            closed folds. The scrollbar top position reflects the window's top
            virtual line number relative to the document's virtual line count.

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -50,6 +50,9 @@ have the highest precedence, and global variables have the lowest).
 *scrollview_on_startup*                   `1`
   Specifies whether scrollbars are        Considered only at global scope
   enabled on startup
+*scrollview_mode*                         `'default'`
+  Specifies what the scrollbar            See |scrollview-modes| for details on
+  position and size correspond to         the available modes
 *scrollview_excluded_filetypes*           `[]`
   Optional file types for which
   scrollbars should not be displayed
@@ -77,6 +80,32 @@ example.
 	" Position the scrollbar at the 80th character of the buffer
 	let g:scrollview_base = 'buffer'
 	let g:scrollview_column = 80
+
+Scrollview Modes ~
+                                           *scrollview-modes*
+The following modes are available for the |scrollview_mode| configuration
+setting (set as a |string|).
+
+Mode       Description
+----       -----------
+*default*    The scrollbar top position reflects the window's top line number
+           relative to the document's line count. The scrollbar height reflects
+           the size of the window relative to the document's line count.
+
+*document*   The scrollbar top position reflects the window's top line number
+           relative to the document's line count. The scrollbar bottom
+           position reflects the window's bottom line number relative to the
+           document's line count. Thus, the scrollbar height reflects the
+           number of lines in the window (counting lines in closed folds)
+           relative to the document's line count.
+
+*virtual*    The scrollbar position and height are calculated similarly to
+           the |default| mode, but line numbers and the document line count
+           are implicitly updated to virtual counterparts that account for
+           closed folds. The scrollbar top position reflects the window's top
+           virtual line number relative to the document's virtual line count.
+           The scrollbar height reflects the size of the window relative to
+           the document's virtual line count.
 
 Color Customization ~
                                            *scrollview-color-customization*

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -84,7 +84,8 @@ example.
 Scrollview Modes ~
                                            *scrollview-modes*
 The following modes are available for the |scrollview_mode| configuration
-setting (set as a |string|).
+setting (set as a |string|). Without closed |folds|, all three modes work the
+same way.
 
 Mode       Description
 ----       -----------
@@ -92,12 +93,12 @@ Mode       Description
            relative to the document's line count. The scrollbar height reflects
            the size of the window relative to the document's line count.
 
-*document*   The scrollbar top position reflects the window's top line number
-           relative to the document's line count. The scrollbar bottom
-           position reflects the window's bottom line number relative to the
-           document's line count. Thus, the scrollbar height reflects the
-           number of lines in the window (counting lines in closed folds)
-           relative to the document's line count.
+*flexible*   The scrollbar height adapts to reflect the number of lines in the
+           window, counting lines in closed folds, relative to the document's
+           line count. The scrollbar top position reflects the window's top
+           line number relative to the document's line count. The scrollbar
+           bottom position reflects the window's bottom line number relative
+           to the document's line count.
 
 *virtual*    The scrollbar position and height are calculated similarly to
            the |simple| mode, but line numbers and the document line count

--- a/doc/tags
+++ b/doc/tags
@@ -1,8 +1,7 @@
 :ScrollViewDisable	scrollview.txt	/*:ScrollViewDisable*
 :ScrollViewEnable	scrollview.txt	/*:ScrollViewEnable*
 :ScrollViewRefresh	scrollview.txt	/*:ScrollViewRefresh*
-default	scrollview.txt	/*default*
-document	scrollview.txt	/*document*
+flexible	scrollview.txt	/*flexible*
 nvim-scrollview	scrollview.txt	/*nvim-scrollview*
 scrollview-color-customization	scrollview.txt	/*scrollview-color-customization*
 scrollview-configuration	scrollview.txt	/*scrollview-configuration*
@@ -19,4 +18,5 @@ scrollview_excluded_filetypes	scrollview.txt	/*scrollview_excluded_filetypes*
 scrollview_mode	scrollview.txt	/*scrollview_mode*
 scrollview_on_startup	scrollview.txt	/*scrollview_on_startup*
 scrollview_winblend	scrollview.txt	/*scrollview_winblend*
+simple	scrollview.txt	/*simple*
 virtual	scrollview.txt	/*virtual*

--- a/doc/tags
+++ b/doc/tags
@@ -1,11 +1,14 @@
 :ScrollViewDisable	scrollview.txt	/*:ScrollViewDisable*
 :ScrollViewEnable	scrollview.txt	/*:ScrollViewEnable*
 :ScrollViewRefresh	scrollview.txt	/*:ScrollViewRefresh*
+default	scrollview.txt	/*default*
+document	scrollview.txt	/*document*
 nvim-scrollview	scrollview.txt	/*nvim-scrollview*
 scrollview-color-customization	scrollview.txt	/*scrollview-color-customization*
 scrollview-configuration	scrollview.txt	/*scrollview-configuration*
 scrollview-installation	scrollview.txt	/*scrollview-installation*
 scrollview-issues	scrollview.txt	/*scrollview-issues*
+scrollview-modes	scrollview.txt	/*scrollview-modes*
 scrollview-requirements	scrollview.txt	/*scrollview-requirements*
 scrollview-usage	scrollview.txt	/*scrollview-usage*
 scrollview.txt	scrollview.txt	/*scrollview.txt*
@@ -13,5 +16,7 @@ scrollview_base	scrollview.txt	/*scrollview_base*
 scrollview_column	scrollview.txt	/*scrollview_column*
 scrollview_current_only	scrollview.txt	/*scrollview_current_only*
 scrollview_excluded_filetypes	scrollview.txt	/*scrollview_excluded_filetypes*
+scrollview_mode	scrollview.txt	/*scrollview_mode*
 scrollview_on_startup	scrollview.txt	/*scrollview_on_startup*
 scrollview_winblend	scrollview.txt	/*scrollview_winblend*
+virtual	scrollview.txt	/*virtual*

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -1,0 +1,25 @@
+-- Returns the count of visible lines between the specified start and end
+-- lines, in the current window's buffer.
+local function scrollview_visible_line_count(start, _end)
+  local count = 0
+  if start < 1 then
+    start = 1
+  end
+  if _end > vim.fn.line('$') then
+    _end = vim.fn.line('$')
+  end
+  local line = start
+  while line <= _end do
+    count = count + 1
+    foldclosedend = vim.fn.foldclosedend(line)
+    if foldclosedend ~= -1 then
+      line = foldclosedend
+    end
+    line = line + 1
+  end
+  return count
+end
+
+return {
+  visible_line_count = scrollview_visible_line_count
+}

--- a/plugin/scrollview.vim
+++ b/plugin/scrollview.vim
@@ -23,6 +23,7 @@ endif
 " *************************************************
 
 let g:scrollview_on_startup = get(g:, 'scrollview_on_startup', 1)
+let g:scrollview_mode = get(g:, 'scrollview_mode', 'default')
 let g:scrollview_excluded_filetypes = 
       \ get(g:, 'scrollview_excluded_filetypes', [])
 let g:scrollview_current_only = get(g:, 'scrollview_current_only', 0)

--- a/plugin/scrollview.vim
+++ b/plugin/scrollview.vim
@@ -23,7 +23,7 @@ endif
 " *************************************************
 
 let g:scrollview_on_startup = get(g:, 'scrollview_on_startup', 1)
-let g:scrollview_mode = get(g:, 'scrollview_mode', 'default')
+let g:scrollview_mode = get(g:, 'scrollview_mode', 'simple')
 let g:scrollview_excluded_filetypes = 
       \ get(g:, 'scrollview_excluded_filetypes', [])
 let g:scrollview_current_only = get(g:, 'scrollview_current_only', 0)


### PR DESCRIPTION
This adds support for different ways of handling folds. Additionally, `redraw` is no longer called, which prevents flickering.