### PR TITLE
Make virtual line calculations loop over folds (instead of lines), and make 'virtual' the default mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ There are various settings that can be configured.
 * Whether scrollbars should be displayed in all windows, or just the current
   window
   - `scrollview_current_only`
-* What the scrollbar position and size correspond to (corresponds to how folds
-  are accounted for)
+* What the scrollbar position and size correspond to (i.e., how folds are
+  accounted for)
   - `scrollview_mode`
 * Scrollbar anchor column and offset
   - `scrollview_base`

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -77,10 +77,19 @@ function! s:WindowHasFold(winid) abort
   if foldlevel(1) !=# 0
     let l:result = 1
   else
+    " Temporarily disable scrollbind and cursorbind so that diff mode and
+    " other functionality that utilizes binding (e.g., :Gdiff, :Gblame) can
+    " function properly.
+    let l:scrollbind = &l:scrollbind
+    let l:cursorbind = &l:cursorbind
+    setlocal noscrollbind
+    setlocal nocursorbind
     let l:view = winsaveview()
     keepjumps normal! ggzj
     let l:result = line('.') !=# 1
     call winrestview(l:view)
+    let &l:scrollbind = l:scrollbind
+    let &l:cursorbind = l:cursorbind
   endif
   call win_gotoid(l:init_winid)
   return l:result

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -328,12 +328,12 @@ function! s:LineRange(winid) abort
   let l:current_winid = win_getid(winnr())
   call win_gotoid(a:winid)
   " Using scrolloff=0 combined with H and L breaks diff mode. Scrolling is not
-  " possible and/or the window scrolls when it shouldn't.
+  " possible and/or the window scrolls when it shouldn't. Temporarily turning
+  " off scrollbind and cursorbind accommodates, but the following is simpler.
   let l:topline = line('w0')
   let l:botline = line('w$')
-  if l:botline < l:topline
-    throw 'No lines are visible'
-  endif
+  " line('w$') returns 0 in silent Ex mode.
+  let l:botline = max([1, l:botline])
   call win_gotoid(l:current_winid)
   return [l:topline, l:botline]
 endfunction

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -275,32 +275,29 @@ function! s:VirtualProportionLine(winid, proportion) abort
   setl noscrollbind
   setl nocursorbind
   let l:view = winsaveview()
-  " Lines are 0-indexed for calculations.
   let l:line = 0
   let l:virtual_line = 0
   let l:prop = 0.0
   let l:virtual_line_count = s:VirtualLineCount(l:winid, 1, '$')
   if l:virtual_line_count ># 1
     keepjumps normal! gg
-    let l:count = 1
     while 1
       let [l:range_start, l:range_end, l:fold] = s:AdvanceVisibleSpan()
       "echom  a:proportion
       let l:line_delta = l:range_end - l:range_start + 1
       let l:virtual_line_delta = l:fold ? 1 : l:line_delta
-      let l:prop_delta = s:NumberToFloat(l:virtual_line_delta - 1) / (l:virtual_line_count - 1)
+      let l:prop_delta = s:NumberToFloat(l:virtual_line_delta) / (l:virtual_line_count - 1)
 
       if l:prop + l:prop_delta >=# a:proportion
         let l:ratio = (a:proportion - l:prop) / l:prop_delta
         let l:prop += l:ratio * l:prop_delta
-        let l:line += float2nr(round(l:ratio * (l:line_delta - l:count)))
+        let l:line += float2nr(round(l:ratio * l:line_delta)) + 1
         break
       endif
-      let l:count += 1
 
       let l:line += l:line_delta
       let l:virtual_line += l:virtual_line_delta
-      let l:prop = s:NumberToFloat(l:virtual_line - 1) / (l:virtual_line_count - 1)
+      let l:prop = s:NumberToFloat(l:virtual_line) / (l:virtual_line_count - 1)
 
       if line('.') ==# 1
         " TODO: set line to end of document.
@@ -308,8 +305,6 @@ function! s:VirtualProportionLine(winid, proportion) abort
       endif
     endwhile
   endif
-  " Convert back to 1-indexing.
-  let l:line += 1
   let l:line = max([1, l:line])
   let l:line = min([line('$'), l:line])
   let l:foldclosed = foldclosed(l:line)

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -680,7 +680,7 @@ function! s:SetTopLine(winid, linenr) abort
   " topline and other values accordingly.
   " WARN: Unlike other functions that move the cursor (e.g., VirtualLineCount,
   " VirtualProportionLine), cursorbind and scrollbind should not be disabled
-  " for SetTopLine, since the windows would not stay in sync otherwise.
+  " for SetTopLine, since bound windows would not stay in sync otherwise.
   let l:winid = a:winid
   let l:linenr = a:linenr
   let l:init_winid = win_getid()

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -212,8 +212,8 @@ function! s:VirtualLineCount(winid, start, end) abort
   " properly.
   let l:scrollbind = &l:scrollbind
   let l:cursorbind = &l:scrollbind
-  setl noscrollbind
-  setl nocursorbind
+  setlocal noscrollbind
+  setlocal nocursorbind
   let l:view = winsaveview()
   let l:start = a:start
   let l:end = a:end
@@ -272,8 +272,8 @@ function! s:VirtualProportionLine(winid, proportion) abort
   " properly.
   let l:scrollbind = &l:scrollbind
   let l:cursorbind = &l:scrollbind
-  setl noscrollbind
-  setl nocursorbind
+  setlocal noscrollbind
+  setlocal nocursorbind
   let l:view = winsaveview()
   let l:line = 0
   let l:virtual_line = 0

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -530,7 +530,7 @@ endfunction
 " state that can be used for restoration.
 function! s:Init()
   " WARN: scrollbind and cursorbind should not be disabled here, as it should
-  " not be disabled for some functionality.
+  " not be disabled for some functionality (e.g., s:SetTopLine).
   let l:state = {
         \   'belloff': &belloff,
         \   'eventignore': &eventignore,

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -196,7 +196,7 @@ function! s:VirtualLineCountOld(winid, start, end) abort
     let l:end = line('$')
   endif
   let l:module = luaeval('require("scrollview")')
-  let l:result = l:module.visible_line_count(a:start, l:end)
+  let l:result = l:module.visible_line_count_old(a:start, l:end)
   call win_gotoid(l:current_winid)
   return l:result
 endfunction
@@ -254,7 +254,7 @@ function! s:VirtualProportionLineOld(winid, start, end, proportion) abort
     let l:end = line('$')
   endif
   let l:module = luaeval('require("scrollview")')
-  let l:result = l:module.visible_proportion_line(
+  let l:result = l:module.visible_proportion_line_old(
         \ a:start, l:end, a:proportion)
   call win_gotoid(l:current_winid)
   return l:result

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -227,19 +227,17 @@ endfunction
 function! s:LineRange(winid) abort
   " WARN: getwininfo(winid)[0].botline is not properly updated for some
   " movements (Neovim Issue #13510), so this is implemeneted as a workaround.
-  " This was originally handled by using an asyncronous context, but this was
+  " This was originally handled by using an asynchronous context, but this was
   " not possible for refreshing bars during mouse drags.
   let l:current_winid = win_getid(winnr())
   call win_gotoid(a:winid)
-  let l:view = winsaveview()
-  let l:scrolloff = getwinvar(a:winid, '&scrolloff')
-  setlocal scrolloff=0
-  keepjumps normal! H
-  let l:topline = line('.')
-  keepjumps normal! L
-  let l:botline = line('.')
-  call setwinvar(a:winid, '&scrolloff', l:scrolloff)
-  call winrestview(l:view)
+  " Using scrolloff=0 combined with H and L breaks diff mode. Scrolling is not
+  " possible and/or the window scrolls when it shouldn't.
+  let l:topline = line('w0')
+  let l:botline = line('w$')
+  if l:botline < l:topline
+    throw 'No lines are visible'
+  endif
   call win_gotoid(l:current_winid)
   return [l:topline, l:botline]
 endfunction

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -211,7 +211,7 @@ function! s:VirtualLineCount(winid, start, end) abort
   " functionality that utilizes binding (e.g., :Gdiff, :Gblame) can function
   " properly.
   let l:scrollbind = &l:scrollbind
-  let l:cursorbind = &l:scrollbind
+  let l:cursorbind = &l:cursorbind
   setlocal noscrollbind
   setlocal nocursorbind
   let l:view = winsaveview()
@@ -238,7 +238,7 @@ function! s:VirtualLineCount(winid, start, end) abort
   endif
   call winrestview(l:view)
   let &l:scrollbind = l:scrollbind
-  let &l:cursorbind = l:scrollbind
+  let &l:cursorbind = l:cursorbind
   call win_gotoid(l:current_winid)
   return l:count
 endfunction
@@ -271,7 +271,7 @@ function! s:VirtualProportionLine(winid, proportion) abort
   " functionality that utilizes binding (e.g., :Gdiff, :Gblame) can function
   " properly.
   let l:scrollbind = &l:scrollbind
-  let l:cursorbind = &l:scrollbind
+  let l:cursorbind = &l:cursorbind
   setlocal noscrollbind
   setlocal nocursorbind
   let l:view = winsaveview()
@@ -312,7 +312,7 @@ function! s:VirtualProportionLine(winid, proportion) abort
   endif
   call winrestview(l:view)
   let &l:scrollbind = l:scrollbind
-  let &l:cursorbind = l:scrollbind
+  let &l:cursorbind = l:cursorbind
   call win_gotoid(l:current_winid)
   return l:line
 endfunction

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -283,24 +283,23 @@ function! s:VirtualProportionLine(winid, proportion) abort
     keepjumps normal! gg
     while 1
       let [l:range_start, l:range_end, l:fold] = s:AdvanceVisibleSpan()
-      "echom  a:proportion
       let l:line_delta = l:range_end - l:range_start + 1
       let l:virtual_line_delta = l:fold ? 1 : l:line_delta
-      let l:prop_delta = s:NumberToFloat(l:virtual_line_delta) / (l:virtual_line_count - 1)
-
+      let l:prop_delta = s:NumberToFloat(l:virtual_line_delta)
+      let l:prop_delta /= (l:virtual_line_count - 1)
       if l:prop + l:prop_delta >=# a:proportion
         let l:ratio = (a:proportion - l:prop) / l:prop_delta
         let l:prop += l:ratio * l:prop_delta
         let l:line += float2nr(round(l:ratio * l:line_delta)) + 1
         break
       endif
-
       let l:line += l:line_delta
       let l:virtual_line += l:virtual_line_delta
-      let l:prop = s:NumberToFloat(l:virtual_line) / (l:virtual_line_count - 1)
-
+      let l:prop =
+            \ s:NumberToFloat(l:virtual_line) / (l:virtual_line_count - 1)
       if line('.') ==# 1
-        " TODO: set line to end of document.
+        " AdvanceVisibleSpan looped back to the beginning of the document.
+        let l:line = line('$')
         break
       endif
     endwhile

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -332,8 +332,9 @@ function! s:LineRange(winid) abort
   " off scrollbind and cursorbind accommodates, but the following is simpler.
   let l:topline = line('w0')
   let l:botline = line('w$')
-  " line('w$') returns 0 in silent Ex mode.
-  let l:botline = max([1, l:botline])
+  " line('w$') returns 0 in silent Ex mode, but line('w0') is always greater
+  " than or equal to 1.
+  let l:botline = max([l:botline, l:topline])
   call win_gotoid(l:current_winid)
   return [l:topline, l:botline]
 endfunction

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -69,7 +69,7 @@ have the highest precedence, and global variables have the lowest).
 *scrollview_on_startup*                   `1`
   Specifies whether scrollbars are        Considered only at global scope
   enabled on startup
-*scrollview_mode*                         `'simple'`
+*scrollview_mode*                         `'virtual'`
   Specifies what the scrollbar            See |scrollview-modes| for details on
   position and size correspond to         the available modes
 *scrollview_excluded_filetypes*           `[]`
@@ -116,24 +116,20 @@ same way.
 
 Mode       Description
 ----       -----------
-*simple*     The scrollbar top position reflects the window's top line number
-           relative to the document's line count. The scrollbar height reflects
-           the size of the window relative to the document's line count.
-
-*flexible*   The scrollbar height adapts to reflect the number of lines in the
-           window, counting lines in closed folds, relative to the document's
-           line count. The scrollbar top position reflects the window's top
+*simple*     (`deprecated`) The scrollbar top position reflects the window's top
            line number relative to the document's line count. The scrollbar
-           bottom position reflects the window's bottom line number relative
-           to the document's line count.
+           height reflects the size of the window relative to the document's
+           line count. Dragging the scrollbars with the mouse may result in
+           unresponsive scrolling and/or erratic scrollbar behavior when there
+           are closed folds.
 
-*virtual*    The scrollbar position and height are calculated similarly to
-           the |simple| mode, but line numbers and the document line count
-           are implicitly updated to virtual counterparts that account for
-           closed folds. The scrollbar top position reflects the window's top
-           virtual line number relative to the document's virtual line count.
-           The scrollbar height reflects the size of the window relative to
-           the document's virtual line count.
+*virtual*    The scrollbar position and height are calculated similarly to the
+           |simple| mode, but line numbers and the document line count are
+           implicitly updated to virtual counterparts that account for closed
+           folds. The scrollbar top position reflects the window's top virtual
+           line number relative to the document's virtual line count. The
+           scrollbar height reflects the size of the window relative to the
+           document's virtual line count.
 
 Color Customization ~
                                            *scrollview-color-customization*

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -1,6 +1,10 @@
+local function test(x, y)
+  vim.cmd('echo "hello world"')
+end
+
 -- Returns the count of visible lines between the specified start and end
 -- lines, in the current window's buffer.
-local function scrollview_visible_line_count(start, _end)
+local function scrollview_visible_line_count_old(start, _end)
   if start < 1 then
     start = 1
   end
@@ -23,14 +27,14 @@ end
 -- Returns the line at the approximate visible proportion between the specified
 -- start and end lines, in the current window's buffer. If the result is in a
 -- closed fold, it is converted to the first line in that fold.
-local function scrollview_visible_proportion_line(start, _end, proportion)
+local function scrollview_visible_proportion_line_old(start, _end, proportion)
   if start < 1 then
     start = 1
   end
   if _end > vim.fn.line('$') then
     _end = vim.fn.line('$')
   end
-  local total = scrollview_visible_line_count(start, _end)
+  local total = scrollview_visible_line_count_old(start, _end)
   local best = start
   local best_distance = math.huge
   if total > 1 then
@@ -59,6 +63,6 @@ local function scrollview_visible_proportion_line(start, _end, proportion)
 end
 
 return {
-  visible_line_count = scrollview_visible_line_count,
-  visible_proportion_line = scrollview_visible_proportion_line
+  visible_line_count_old = scrollview_visible_line_count_old,
+  visible_proportion_line_old = scrollview_visible_proportion_line_old
 }

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -32,6 +32,9 @@ local function scrollview_advance_visible_span()
   end
 end
 
+-- Returns the count of visible lines between the specified start and end lines
+-- (both inclusive), in the specified window. A closed fold counts as on
+-- visible line. '$' can be used as the end line, to represent the last line.
 local function scrollview_virtual_line_count(winid, start, _end)
   local current_winid = vim.fn.win_getid(vim.fn.winnr())
   vim.fn.win_gotoid(winid)

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -1,7 +1,101 @@
-local function test(x, y)
-  vim.cmd('echo "hello world"')
+-- Advance the current window cursor to the start of the next visible span,
+-- returning the range of lines jumped over, and a boolean indicating whether
+-- that range was in a closed fold. If there is no next visible span, the
+-- cursor is returned to the first line.
+local function scrollview_advance_visible_span()
+  local start = vim.fn.line('.')
+  local foldclosedend = vim.fn.foldclosedend(start)
+  if foldclosedend ~= -1 then
+    -- The cursor started on a closed fold.
+    if foldclosedend == vim.fn.line('$') then
+      vim.cmd('keepjumps normal! gg')
+    else
+      vim.cmd('keepjumps normal! j')
+    end
+    return {start, foldclosedend, true}
+  end
+  local lnum = start
+  while true do
+    vim.cmd('keepjumps normal! zj')
+    if lnum == vim.fn.line('.') then
+      -- There are no more folds after the cursor. This is the last span.
+      vim.cmd('keepjumps normal! gg')
+      return {start, vim.fn.line('$'), false}
+    end
+    lnum = vim.fn.line('.')
+    local foldclosed = vim.fn.foldclosed(lnum)
+    if foldclosed ~= -1 then
+      -- The cursor moved to a closed fold. The preceding line ends the prior
+      -- visible span.
+      return {start, lnum - 1, false}
+    end
+  end
 end
 
+local function scrollview_virtual_line_count(winid, start, _end)
+  local current_winid = vim.fn.win_getid(vim.fn.winnr())
+  vim.fn.win_gotoid(winid)
+  -- Temporarily disable scrollbind and cursorbind so that diff mode and other
+  -- functinoality that utilizes binding (e.g., :Gdiff, :Gblame) can function
+  -- properly.
+  local scrollbind = vim.wo.scrollbind
+  local cursorbind = vim.wo.cursorbind
+  vim.wo.scrollbind = false
+  vim.wo.cursorbind = false
+  local view = vim.fn.winsaveview()
+  if type(_end) == 'string' and _end == '$' then
+    _end = vim.fn.line('$')
+  end
+  start = math.max(1, start)
+  _end = math.min(vim.fn.line('$'), _end)
+  local count = 0
+  if _end >= start then
+    vim.cmd('keepjumps normal! ' .. start .. 'G')
+    while true do
+      local range_start, range_end, fold =
+        unpack(scrollview_advance_visible_span())
+      range_end = math.min(range_end, _end)
+      local delta = 1
+      if not fold then
+        delta = range_end - range_start + 1
+      end
+      count = count + delta
+      if range_end == _end or vim.fn.line('.') == 1 then
+        break
+      end
+    end
+  end
+  vim.fn.winrestview(view)
+  vim.wo.scrollbind = scrollbind
+  vim.wo.cursorbind = cursorbind
+  vim.fn.win_gotoid(current_winid)
+  return count
+end
+
+-- TODO: DELETE
+-- Returns the count of visible lines between the specified start and end
+-- lines, in the current window's buffer.
+local function scrollview_visible_line_count(start, _end)
+  if start < 1 then
+    start = 1
+  end
+  if _end > vim.fn.line('$') then
+    _end = vim.fn.line('$')
+  end
+  local count = 0
+  local line = start
+  while line <= _end do
+    count = count + 1
+    foldclosedend = vim.fn.foldclosedend(line)
+    if foldclosedend ~= -1 then
+      line = foldclosedend
+    end
+    line = line + 1
+  end
+  return count
+end
+
+-- TODO: DELETE
 -- Returns the count of visible lines between the specified start and end
 -- lines, in the current window's buffer.
 local function scrollview_visible_line_count_old(start, _end)
@@ -24,6 +118,7 @@ local function scrollview_visible_line_count_old(start, _end)
   return count
 end
 
+-- TODO: DELETE
 -- Returns the line at the approximate visible proportion between the specified
 -- start and end lines, in the current window's buffer. If the result is in a
 -- closed fold, it is converted to the first line in that fold.
@@ -63,6 +158,7 @@ local function scrollview_visible_proportion_line_old(start, _end, proportion)
 end
 
 return {
-  visible_line_count_old = scrollview_visible_line_count_old,
-  visible_proportion_line_old = scrollview_visible_proportion_line_old
+  advance_visible_span = scrollview_advance_visible_span, -- TODO: REMOVE
+  virtual_line_count = scrollview_virtual_line_count,
+  visible_proportion_line_old = scrollview_visible_proportion_line_old -- TODO: REMOVE
 }

--- a/plugin/scrollview.vim
+++ b/plugin/scrollview.vim
@@ -23,7 +23,7 @@ endif
 " *************************************************
 
 let g:scrollview_on_startup = get(g:, 'scrollview_on_startup', 1)
-let g:scrollview_mode = get(g:, 'scrollview_mode', 'simple')
+let g:scrollview_mode = get(g:, 'scrollview_mode', 'virtual')
 let g:scrollview_excluded_filetypes = 
       \ get(g:, 'scrollview_excluded_filetypes', [])
 let g:scrollview_current_only = get(g:, 'scrollview_current_only', 0)


### PR DESCRIPTION
This PR updates the virtual line calculations to loop over folds, as opposed to looping over lines. This is faster, as the number of folds is less than the number of lines, and ordinarily substantially smaller.

The default scrollview mode was changed from `simple` to `virtual`.

The `flexible` mode was removed. Scrollbar mouse dragging assumes the height of the scrollbar remains fixed.

The `simple` mode was deprecated.

