### PR TITLE
Scrollbar Dragging Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ There are various settings that can be configured.
   - `scrollview_auto_mouse`
 * Whether select workarounds are automatically applied for known issues
   - `scrollview_auto_workarounds`
+* Whether to apply a workaround for [Neovim Issue #14040][neovim_14040]
+  - `scrollview_nvim_14040_workaround`
 
 Please see the documentation for details.
 
@@ -95,6 +97,7 @@ See [LICENSE](LICENSE).
 
 [dein]: https://github.com/Shougo/dein.vim
 [neobundle]: https://github.com/Shougo/neobundle.vim
+[neovim_14040]: https://github.com/neovim/neovim/issues/14040
 [packer]: https://github.com/wbthomason/packer.nvim
 [pathogen]: https://github.com/tpope/vim-pathogen
 [vim8pack]: http://vimhelp.appspot.com/repeat.txt.html#packages

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -52,6 +52,11 @@ endfunction
 " * Core
 " *************************************************
 
+" (documented in scrollview.lua)
+function! s:CloseWindow(winid) abort
+  call s:lua_module.close_window(a:winid)
+endfunction
+
 " Returns true for ordinary windows (not floating and not external), and
 " false otherwise.
 function! s:IsOrdinaryWindow(winid) abort
@@ -106,7 +111,7 @@ function! s:WindowHasFold(winid) abort
     " Leave the workspace so it can be closed. Return to the existing window,
     " which was l:winid (from the win_gotoid call above).
     call win_gotoid(l:winid)
-    call nvim_win_close(l:workspace_winid, 1)
+    call s:CloseWindow(l:workspace_winid)
   endif
   call win_gotoid(l:init_winid)
   return l:result
@@ -402,7 +407,7 @@ function! s:CloseScrollViewWindow(winid) abort
   if !s:IsScrollViewWindow(l:winid)
     return
   endif
-  silent! noautocmd call nvim_win_close(l:winid, 1)
+  silent! noautocmd call s:CloseWindow(l:winid)
 endfunction
 
 " Sets global state that is assumed by the core functionality and returns a

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -97,6 +97,10 @@ have the highest precedence, and global variables have the lowest).
   are automatically applied for known     when the plugin is loaded
   |scrollview-issues| (without
   clobbering existing customizations)
+*scrollview_nvim_14040_workaround*        `0`
+  Specifies whether a workaround is       Considered only at global scope
+  used for Neovim Issue #14040
+  (see |scrollview-memory-leak-issue|)
 
 The variables can be customized in your |init.vim|, as shown in the following
 example.
@@ -254,6 +258,11 @@ Error Message Issues ~
           \ silent! ScrollViewDisable
           \ | bdelete
           \ | silent! ScrollViewEnable
+
+Memory Leak Issue ~
+                                           *scrollview-memory-leak-issue*
+* Memory leaks when there are folds. Neovim Issue #14040 is the corresponding
+  issue, opened March 1, 2021.
 
 ============================================================================
  vim:tw=78:ts=4:ft=help:norl:

--- a/doc/tags
+++ b/doc/tags
@@ -1,7 +1,6 @@
 :ScrollViewDisable	scrollview.txt	/*:ScrollViewDisable*
 :ScrollViewEnable	scrollview.txt	/*:ScrollViewEnable*
 :ScrollViewRefresh	scrollview.txt	/*:ScrollViewRefresh*
-flexible	scrollview.txt	/*flexible*
 nvim-scrollview	scrollview.txt	/*nvim-scrollview*
 scrollview-color-customization	scrollview.txt	/*scrollview-color-customization*
 scrollview-commands	scrollview.txt	/*scrollview-commands*
@@ -10,6 +9,7 @@ scrollview-error-message-issues	scrollview.txt	/*scrollview-error-message-issues
 scrollview-installation	scrollview.txt	/*scrollview-installation*
 scrollview-issues	scrollview.txt	/*scrollview-issues*
 scrollview-mappings	scrollview.txt	/*scrollview-mappings*
+scrollview-memory-leak-issue	scrollview.txt	/*scrollview-memory-leak-issue*
 scrollview-modes	scrollview.txt	/*scrollview-modes*
 scrollview-mouse-customization	scrollview.txt	/*scrollview-mouse-customization*
 scrollview-requirements	scrollview.txt	/*scrollview-requirements*
@@ -17,11 +17,13 @@ scrollview-synchronization-issues	scrollview.txt	/*scrollview-synchronization-is
 scrollview-usage	scrollview.txt	/*scrollview-usage*
 scrollview.txt	scrollview.txt	/*scrollview.txt*
 scrollview_auto_mouse	scrollview.txt	/*scrollview_auto_mouse*
+scrollview_auto_workarounds	scrollview.txt	/*scrollview_auto_workarounds*
 scrollview_base	scrollview.txt	/*scrollview_base*
 scrollview_column	scrollview.txt	/*scrollview_column*
 scrollview_current_only	scrollview.txt	/*scrollview_current_only*
 scrollview_excluded_filetypes	scrollview.txt	/*scrollview_excluded_filetypes*
 scrollview_mode	scrollview.txt	/*scrollview_mode*
+scrollview_nvim_14040_workaround	scrollview.txt	/*scrollview_nvim_14040_workaround*
 scrollview_on_startup	scrollview.txt	/*scrollview_on_startup*
 scrollview_winblend	scrollview.txt	/*scrollview_winblend*
 simple	scrollview.txt	/*simple*

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -29,6 +29,17 @@ local function round(x)
   return math.floor(x + 0.5)
 end
 
+-- Returns true for boolean true and any non-zero number, otherwise returns
+-- false.
+local function to_bool(x)
+  if type(x) == 'boolean' then
+    return x
+  elseif type(x) == 'number' then
+    return x ~= 0
+  end
+  return false
+end
+
 -- *************************************************
 -- * Core
 -- *************************************************
@@ -40,7 +51,9 @@ end
 -- otherwise.
 local function close_window(winid)
   local config = vim.api.nvim_win_get_config(winid)
-  if config.relative ~= '' then
+  local nvim_14040_workaround =
+    to_bool(vim.g.scrollview_nvim_14040_workaround)
+  if config.relative ~= '' and nvim_14040_workaround then
     local current_winid = vim.fn.win_getid(vim.fn.winnr())
     vim.api.nvim_set_current_win(winid)
     for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do

--- a/plugin/scrollview.vim
+++ b/plugin/scrollview.vim
@@ -40,6 +40,8 @@ let g:scrollview_column = get(g:, 'scrollview_column', 2)
 let g:scrollview_base = get(g:, 'scrollview_base', 'right')
 let g:scrollview_auto_mouse = get(g:, 'scrollview_auto_mouse', 1)
 let g:scrollview_auto_workarounds = get(g:, 'scrollview_auto_workarounds', 1)
+let g:scrollview_nvim_14040_workaround =
+      \ get(g:, 'scrollview_nvim_14040_workaround', 0)
 
 " *************************************************
 " * Commands


### PR DESCRIPTION
This adds various optimizations to make scrollbar dragging faster, particularly when there are many folds.

1. Lua functions are memoized for the duration of dragging, since for any given inputs, the returned values cannot change during this time.
2. The entire input stream is emptied when obtaining mouse events. This reduces the number of times that the overlay has to be shown (which is used to accurately obtain mouse position coordinates).
3. When multiple mouse dragging events are read at the same time from the input stream (possible from update 2 above), only the most recent drag event is used for repositioning.

Additionally, a workaround was added for [Neovim Issue #14040](https://github.com/neovim/neovim/issues/14040). Because this trades off with speed, it is currently off by default.