### PR TITLE
Use asynchronous refreshing.

### DIFF
--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -750,6 +750,16 @@ function! scrollview#RemoveBars() abort
   endtry
 endfunction
 
+" Remove scrollbars if InCommandLineWindow is true. This fails when called
+" from the CmdwinEnter event (some functionality, like nvim_win_close,
+" cannot be used from the command line window), but works during the
+" transition to the command line window (from the WinEnter event).
+function! scrollview#RemoveIfCommandLineWindow() abort
+  if s:InCommandLineWindow()
+    silent! call scrollview#RemoveBars()
+  endif
+endfunction
+
 " Refreshes scrollbars. There is an optional argument that specifies whether
 " removing existing scrollbars is asynchronous (defaults to true).
 function! scrollview#RefreshBars(...) abort
@@ -759,18 +769,7 @@ function! scrollview#RefreshBars(...) abort
   endif
   let l:state = s:Init()
   try
-    " Some functionality, like nvim_win_close, cannot be used from the command
-    " line window.
     if s:InCommandLineWindow()
-      " For the duration of command-line window usage, there will be no bars.
-      " Without this, bars can possibly overlap the command line window. This
-      " can be problematic particularly when there is a vertical split with the
-      " left window's bar on the bottom of the screen, where it would overlap
-      " with the center of the command line window. It was not possible to use
-      " CmdwinEnter, since the removal has to occur prior to that event.
-      " Rather, this is triggered by the WinEnter event, just prior to the
-      " relevant funcionality becoming unavailable.
-      silent! call scrollview#RemoveBars()
       return
     endif
     " Remove any scrollbars that are pending asynchronous removal. This

--- a/plugin/scrollview.vim
+++ b/plugin/scrollview.vim
@@ -158,7 +158,7 @@ endif
 " Internal flag for tracking scrollview state.
 let s:scrollview_enabled = g:scrollview_on_startup
 
-" INFO: Asyncronous refreshing was originally used to work around issues
+" INFO: Asynchronous refreshing was originally used to work around issues
 " (e.g., getwininfo(winid)[0].botline not updated yet in a synchronous
 " context). However, it's now primarily utilized because it makes the UI more
 " responsive and it permits redundant refreshes to be dropped (e.g., for mouse
@@ -232,7 +232,13 @@ endfunction
 
 function! s:ScrollViewRefresh() abort
   if s:scrollview_enabled
-    call scrollview#RefreshBars()
+    " This refresh is asynchronous to keep interactions responsive (e.g.,
+    " mouse wheel scrolling, as redundant async refreshes are dropped). If
+    " scenarios necessitate synchronous refreshes, the interface would have to
+    " be updated to accommodate (as there is currently only a single refresh
+    " command and a single refresh <plug> mapping, both utilizing whatever is
+    " implemented here).
+    call scrollview#RefreshBarsAsync()
   else
     call scrollview#RemoveBars()
   endif


### PR DESCRIPTION
This makes UI interactions more responsive. For example, when changing windows or tabs, now the navigation will be conducted and then followed separately by scrollbars being refreshed (as opposed to having these two steps merged). Additionally, the asynchronous refreshing drops refreshes that would be redundant, which makes mouse wheel scrolling more responsive.