### PR TITLE
Use linewise computations when there are many folds.

### DIFF
--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -594,7 +594,19 @@ function! s:ReadInputStream() abort
   let l:chars_props = []
   let l:str_idx = 0  " in bytes
   while 1
-    let l:char = getchar()
+    try
+      let l:char = getchar()
+    catch
+      " E.g., <c-c>
+      let l:char = "\<esc>"
+    finally
+      " On Cygwin, pressing <c-c> during getchar() does not raise
+      " "Vim:Interrupt", so it would still be <c-c> at this point. Convert to
+      " <esc>.
+      if l:char ==# "\<c-c>"
+        let l:char = "\<esc>"
+      endif
+    endtry
     let l:charmod = getcharmod()
     if type(l:char) ==# v:t_number
       let l:char = nr2char(l:char)
@@ -1014,6 +1026,10 @@ function! scrollview#HandleMouse(button) abort
         endif
         break
       endwhile
+      if l:char ==# "\<esc>"
+        call feedkeys(l:string[l:str_idx + 1:], 'ni')
+        return
+      endif
       if l:mouse_winid ==# 0
         " There was no mouse event.
         call feedkeys(l:string[l:str_idx:], 'ni')

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -600,9 +600,9 @@ function! s:ReadInputStream() abort
       " E.g., <c-c>
       let l:char = "\<esc>"
     finally
-      " On Cygwin, pressing <c-c> during getchar() does not raise
-      " "Vim:Interrupt", so it would still be <c-c> at this point. Convert to
-      " <esc>.
+      " For Vim on Cygwin, pressing <c-c> during getchar() does not raise
+      " "Vim:Interrupt". Handling for such a scenario is added here as a
+      " precaution, by converting to <esc>.
       if l:char ==# "\<c-c>"
         let l:char = "\<esc>"
       endif

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -120,10 +120,10 @@ same way.
 
 Mode       Description
 ----       -----------
-*simple*     (`deprecated`) The scrollbar top position reflects the window's top
-           line number relative to the document's line count. The scrollbar
-           height reflects the size of the window relative to the document's
-           line count. Dragging the scrollbars with the mouse may result in
+*simple*     The scrollbar top position reflects the window's top line number
+           relative to the document's line count. The scrollbar height
+           reflects the size of the window relative to the document's line
+           count. Dragging the scrollbars with the mouse may result in
            unresponsive scrolling when there are closed folds.
 
 *virtual*    The scrollbar position and height are calculated similarly to the


### PR DESCRIPTION
When there are many folds, it is slow to use spanwise computations. This PR updates the code to use linewise computations instead of spanwise computations when there are many folds.