### PR TITLE
Update 'simple' and 'virtual' types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![build][badge_thumbnail]][badge_link]
+
 # nvim-scrollview
 
 `nvim-scrollview` is a Neovim plugin that displays interactive scrollbars.
@@ -101,6 +103,8 @@ The source code has an [MIT License](https://en.wikipedia.org/wiki/MIT_License).
 
 See [LICENSE](LICENSE).
 
+[badge_link]: https://github.com/dstein64/nvim-scrollview/actions/workflows/build.yml
+[badge_thumbnail]: https://github.com/dstein64/nvim-scrollview/actions/workflows/build.yml/badge.svg
 [dein]: https://github.com/Shougo/dein.vim
 [neobundle]: https://github.com/Shougo/neobundle.vim
 [neovim_14040]: https://github.com/neovim/neovim/issues/14040

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -127,14 +127,14 @@ same way.
 
 Mode       Description
 ----       -----------
-*simple*     The scrollbar top position reflects the window's top line number
+`simple`     The scrollbar top position reflects the window's top line number
            relative to the document's line count. The scrollbar height
            reflects the size of the window relative to the document's line
            count. Dragging the scrollbars with the mouse may result in
            unresponsive scrolling when there are closed folds.
 
-*virtual*    The scrollbar position and height are calculated similarly to the
-           |simple| mode, but line numbers and the document line count are
+`virtual`    The scrollbar position and height are calculated similarly to the
+           `simple` mode, but line numbers and the document line count are
            implicitly updated to virtual counterparts that account for closed
            folds. The scrollbar top position reflects the window's top virtual
            line number relative to the document's virtual line count. The

--- a/doc/tags
+++ b/doc/tags
@@ -27,5 +27,3 @@ scrollview_nvim_14040_workaround	scrollview.txt	/*scrollview_nvim_14040_workarou
 scrollview_on_startup	scrollview.txt	/*scrollview_on_startup*
 scrollview_refresh_time	scrollview.txt	/*scrollview_refresh_time*
 scrollview_winblend	scrollview.txt	/*scrollview_winblend*
-simple	scrollview.txt	/*simple*
-virtual	scrollview.txt	/*virtual*


### PR DESCRIPTION
These should not be tag link destinations.
