### PR TITLE
Improve readbility of scrollview.txt

### DIFF
--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -62,52 +62,120 @@ The following variables can be used to customize the behavior of
 and/or 4) global scope, with that order of precedence (i.e., window variables
 have the highest precedence, and global variables have the lowest).
 
-`Variable`                                `Default`
-  Description                             Info
--------------                           -------
 
-*scrollview_on_startup*                   `1`
-  Specifies whether scrollbars are        Considered only at global scope
-  enabled on startup
-*scrollview_mode*                         `'virtual'`
-  Specifies what the scrollbar            See |scrollview-modes| for details on
-  position and size correspond to         the available modes
-*scrollview_excluded_filetypes*           `[]`
-  Optional file types for which
-  scrollbars should not be displayed
-*scrollview_current_only*                 `0`
-  Specifies whether scrollbars should     Considered only at tab and global
-  only be displayed in the current        scopes
-  window
-*scrollview_winblend*                     `50`
-  Specifies the level of transparency     An integer between 0 (opaque) and
-  for scrollbars                          100 (transparent)
-*scrollview_base*                         `'right'`
-  Specifies where the scrollbar is        `'left'` or `'right'` for corresponding
-  anchored                                window edges, or `'buffer'`
-*scrollview_column*                       `2`
-  Specifies the scrollbar column          An integer greater than or equal
-  (relative to |scrollview_base|)           to 1
-*scrollview_auto_mouse*                   `1`
-  Specifies whether a mapping is          Considered only at global scope,
-  automatically created for mouse         when the plugin is loaded
-  support (without clobbering)
-*scrollview_auto_workarounds*             `1`
-  Specifies whether select workarounds    Considered only at global scope,
-  are automatically applied for known     when the plugin is loaded
-  |scrollview-issues| (without
-  clobbering existing customizations)
-*scrollview_nvim_14040_workaround*        `0`
-  Specifies whether a workaround is       Considered only at global scope
-  used for Neovim Issue #14040
-  (see |scrollview-memory-leak-issue|)
-*scrollview_refresh_time*                 `100`
-  When scrollbar refreshing takes more    Considered only at global scope;
-  than this many milliseconds,            A value of -1 corresponds to no
-  subsequent refreshing will use          limit
-  `simple` |scrollview_mode|. Setting
-  `g:scrollview_refresh_time_exceeded`
-  to 0 resets the mode behaviour.
+scrollview_on_startup                                  *scrollview_on_startup*
+
+  Type: |Number|
+  Default: `1`
+
+  Specifies whether scrollbars are enabled on startup.
+
+
+scrollview_mode                                              *scrollview_mode*
+
+  Type: |String|
+  Default: `'virtual'`
+
+  Specifies what the scrollbar position and size correspond to.
+  See |scrollview-modes| for details on the available modes.
+
+
+scrollview_excluded_filetypes                  *scrollview_excluded_filetypes*
+
+  Type: |List|
+  Default: `[]`
+
+  Optional file types for which scrollbars should not be displayed.
+
+
+scrollview_current_only                              *scrollview_current_only*
+
+  Type: |Number|
+  Default: `0`
+
+  Specifies whether scrollbars should only be displayed in the current
+  window.
+
+  Considered only at tab and global scopes.
+
+
+scrollview_winblend                                      *scrollview_winblend*
+
+  Type: |Number|
+  Default: `50`
+
+  Specifies the level of transparency for scrollbars.
+
+  Must be between between 0 (opaque) and 100 (transparent).
+
+
+scrollview_base                                              *scrollview_base*
+
+  Type: |String|
+  Default: `right`
+
+  Specifies where the scrollbar is anchored.
+
+  Possible values are `'left'` or `'right'` for corresponding window edges,
+  or `'buffer'`.
+
+
+scrollview_column                                          *scrollview_column*
+
+  Type: |Number|
+  Default: `2`
+
+  Specifies the scrollbar column (relative to |scrollview_base|).
+
+  Must be an integer greater than or equal to 1.
+
+
+scrollview_auto_mouse                                  *scrollview_auto_mouse*
+
+  Type: |Number|
+  Default: `1`
+
+  Specifies whether a mapping is automatically created for mouse support
+  (without clobbering).
+
+  Considered only at global scope, when the plugin is loaded.
+
+
+scrollview_auto_workarounds                      *scrollview_auto_workarounds*
+
+  Type: |Number|
+  Default: `1`
+
+  Specifies whether select workarounds are automatically applied for known
+  |scrollview-issues| (without clobbering existing customizations).
+
+  Considered only at global scope, when the plugin is loaded.
+
+
+scrollview_nvim_14040_workaround            *scrollview_nvim_14040_workaround*
+
+  Type: |Number|
+  Default: `0`
+
+  Specifies whether a workaround is used for Neovim Issue #14040 (see
+  |scrollview-memory-leak-issue|).
+
+  Considered only at global scope.
+
+
+scrollview_refresh_time                              *scrollview_refresh_time*
+
+  Type: |Number|
+  Default: `100`
+
+  When scrollbar refreshing takes more than this many milliseconds,
+  subsequent refreshing will use `simple` |scrollview_mode|. Setting
+  `scrollview_refresh_time_exceeded` to 0 resets the mode behaviour.
+
+  A value of -1 corresponds to no limit.
+
+  Considered only at global scope.
+
 
 The variables can be customized in your |init.vim|, as shown in the following
 example.


### PR DESCRIPTION
Change the layout of the `scrollview-configuration` section to make it more readable. The column view was difficult to read and a bit cluttered. 