### PR TITLE
Ensure winid from get_windows_options() are always integer

### DIFF
--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -971,7 +971,7 @@ end
 local get_windows_options = function()
   local wins_options = {}
   for _, winid in ipairs(get_ordinary_windows()) do
-    wins_options[tostring(winid)] = fn.getwinvar(winid, '&')
+    wins_options[winid] = fn.getwinvar(winid, '&')
   end
   return wins_options
 end


### PR DESCRIPTION
Due to a breaking change in neovim 0.7.0 (see neovim/neovim#14090),
winid for `nvim_win_xxx(...)` APIs must be of integer types,
no longer allowing implicit conversion from string.

This patch will eliminate an error that will happen otherwise.

References:
https://github.com/neovim/neovim/issues/14090#issuecomment-1004318147
