### PR TITLE
Ensure winid is always integer for state.toplines

### DIFF
--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -860,7 +860,7 @@ local get_toplines = function()
   for _, info in ipairs(fn.getwininfo()) do
     local winid = info.winid
     if info.tabnr == tabnr and is_ordinary_window(winid) then
-      result[tostring(winid)] = info.topline
+      result[winid] = info.topline
     end
   end
   return result


### PR DESCRIPTION
Similar as in 4d382648, winid should be of integer type (not string)
to make nvim_win_call(...) API work correctly in neovim 0.7.0+.
