### PR TITLE
Account for lines after EOF. #58

### DIFF
--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -188,8 +188,8 @@ scrollview_hide_on_intersect               *scrollview_hide_on_intersect*
 scrollview_include_end_region              *scrollview_include_end_region*
                        |Boolean| specifying whether the region beyond the last
                        line is considered for scrollbar height and
-                       positioning. Defaults to |v:false|. See Issue #58 for
-                       details. (`experimental`)
+                       positioning. Defaults to |v:false|. Considered only at
+                       global scope. See Issue #58 for details. (`experimental`)
 
                                            *scrollview_line_limit*
 scrollview_line_limit  |Number| specifying the buffer size threshold (in

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -134,7 +134,7 @@ have the highest precedence, and global variables have the lowest).
 Configuration Variables ~
                                            *scrollview_always_show*
 scrollview_always_show |Boolean| specifying whether scrollbars and signs are
-                       shown when all lines are visible. Defaults to |v:true|.
+                       shown when all lines are visible. Defaults to |v:false|.
 
                                            *scrollview_auto_mouse*
 scrollview_auto_mouse  |Boolean| specifying whether a mapping is automatically

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -185,6 +185,12 @@ scrollview_hide_on_intersect               *scrollview_hide_on_intersect*
                        becomes hidden (not shown) when it would otherwise
                        intersect with a floating window. Defaults to |v:false|.
 
+scrollview_include_end_region              *scrollview_include_end_region*
+                       |Boolean| specifying whether the region beyond the last
+                       line is considered for scrollbar height and
+                       positioning. Defaults to |v:false|. See Issue #58 for
+                       details. (`experimental`)
+
                                            *scrollview_line_limit*
 scrollview_line_limit  |Number| specifying the buffer size threshold (in
                        lines) for entering restricted mode, to prevent slow

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -134,7 +134,7 @@ have the highest precedence, and global variables have the lowest).
 Configuration Variables ~
                                            *scrollview_always_show*
 scrollview_always_show |Boolean| specifying whether scrollbars and signs are
-                       shown when all lines are visible. Defaults to |v:false|.
+                       shown when all lines are visible. Defaults to |v:true|.
 
                                            *scrollview_auto_mouse*
 scrollview_auto_mouse  |Boolean| specifying whether a mapping is automatically

--- a/doc/tags
+++ b/doc/tags
@@ -67,6 +67,7 @@ scrollview_excluded_filetypes	scrollview.txt	/*scrollview_excluded_filetypes*
 scrollview_folds_priority	scrollview.txt	/*scrollview_folds_priority*
 scrollview_folds_symbol	scrollview.txt	/*scrollview_folds_symbol*
 scrollview_hide_on_intersect	scrollview.txt	/*scrollview_hide_on_intersect*
+scrollview_include_end_region	scrollview.txt	/*scrollview_include_end_region*
 scrollview_line_limit	scrollview.txt	/*scrollview_line_limit*
 scrollview_loclist_priority	scrollview.txt	/*scrollview_loclist_priority*
 scrollview_loclist_symbol	scrollview.txt	/*scrollview_loclist_symbol*

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -730,9 +730,7 @@ end
 -- with a height, row, and col. Uses 1-indexing.
 local calculate_position = function(winnr)
   local winid = fn.win_getid(winnr)
-  local bufnr = api.nvim_win_get_buf(winid)
-  local topline, botline = line_range(winid)
-  local line_count = api.nvim_buf_line_count(bufnr)
+  local topline, _ = line_range(winid)
   local the_topline_lookup = topline_lookup(winid)
   -- top is the position for the top of the scrollbar, relative to the window.
   local top = binary_search(the_topline_lookup, topline)

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -1980,7 +1980,6 @@ local handle_mouse = function(button)
     end
     local count = 0
     local winid  -- The target window ID for a mouse scroll.
-    local bufnr  -- The target buffer number.
     local scrollbar_offset
     local previous_row
     local idx = 1
@@ -2123,7 +2122,6 @@ local handle_mouse = function(button)
             vim.cmd('normal! ' .. t'<esc>')
           end
           winid = mouse_winid
-          bufnr = api.nvim_win_get_buf(winid)
           scrollbar_offset = props.row - mouse_row
           previous_row = props.row
         end

--- a/lua/scrollview/utils.lua
+++ b/lua/scrollview/utils.lua
@@ -8,7 +8,11 @@ function M.binary_search(l, x)
   while lo <= hi do
     local mid = math.floor((hi - lo) / 2 + lo)
     if l[mid] == x then
-      return mid
+      if mid == 1 or l[mid - 1] ~= x then
+        return mid
+      end
+      -- Keep searching for the leftmost match.
+      hi = mid - 1
     elseif l[mid] < x then
       lo = lo + 1
     else

--- a/plugin/scrollview.vim
+++ b/plugin/scrollview.vim
@@ -37,7 +37,7 @@ endfunction
 
 " === General ===
 
-let g:scrollview_always_show = get(g:, 'scrollview_always_show', v:false)
+let g:scrollview_always_show = get(g:, 'scrollview_always_show', v:true)
 let g:scrollview_auto_mouse = get(g:, 'scrollview_auto_mouse', v:true)
 let g:scrollview_auto_workarounds =
       \ get(g:, 'scrollview_auto_workarounds', v:true)

--- a/plugin/scrollview.vim
+++ b/plugin/scrollview.vim
@@ -52,6 +52,8 @@ let g:scrollview_excluded_filetypes =
       \ get(g:, 'scrollview_excluded_filetypes', [])
 let g:scrollview_hide_on_intersect =
       \ get(g:, 'scrollview_hide_on_intersect', v:false)
+let g:scrollview_include_end_region =
+      \ get(g:, 'scrollview_include_end_region', v:false)
 " The plugin enters a restricted state when the number of buffer lines exceeds
 " the limit. Use -1 for no limit.
 let g:scrollview_line_limit = get(g:, 'scrollview_line_limit', 20000)

--- a/plugin/scrollview.vim
+++ b/plugin/scrollview.vim
@@ -37,7 +37,7 @@ endfunction
 
 " === General ===
 
-let g:scrollview_always_show = get(g:, 'scrollview_always_show', v:true)
+let g:scrollview_always_show = get(g:, 'scrollview_always_show', v:false)
 let g:scrollview_auto_mouse = get(g:, 'scrollview_auto_mouse', v:true)
 let g:scrollview_auto_workarounds =
       \ get(g:, 'scrollview_auto_workarounds', v:true)


### PR DESCRIPTION
This adds an option to account for lines after EOF (Issue #58), enabled with `scrollview_include_end_region`. That behavior is consistent with how `gvim` and `nvim-qt` (`:GuiScrollBar 1`) show scrollbars.

The functionality is disabled by default.

The default functionality was also updated so that the scrollbar will overflow beyond the bottom of the window when viewing that end region (https://github.com/dstein64/nvim-scrollview/issues/58#issuecomment-1112586814).