### PR TITLE
Allow configure gitsigns sign priority

### DIFF
--- a/lua/scrollview/contrib/gitsigns.lua
+++ b/lua/scrollview/contrib/gitsigns.lua
@@ -101,18 +101,21 @@ function M.setup(config)
     group = group,
     highlight = config.add_highlight,
     symbol = config.add_symbol,
+    priority = config.priority
   }).name
 
   local change = scrollview.register_sign_spec({
     group = group,
     highlight = config.change_highlight,
     symbol = config.change_symbol,
+    priority = config.priority
   }).name
 
   local delete = scrollview.register_sign_spec({
     group = group,
     highlight = config.delete_highlight,
     symbol = config.delete_symbol,
+    priority = config.priority
   }).name
 
   scrollview.set_sign_group_state(group, config.enabled)


### PR DESCRIPTION
In most cases, gitsigns should always be the rightmost, otherwise, other signs will break the line made of gitsigns.
Allow users to configure the priority.

Before(default priority):
![image](https://github.com/dstein64/nvim-scrollview/assets/61115159/dd7e544f-a3bc-489d-a91d-315c13ad5910)

After(priority = 100):
![image](https://github.com/dstein64/nvim-scrollview/assets/61115159/d3efa099-1eab-44b9-958a-f2a0ed0d2828)
