### PR TITLE
Fix wrong vimscript function return value judgment

### DIFF
--- a/lua/scrollview/contrib/gitsigns.lua
+++ b/lua/scrollview/contrib/gitsigns.lua
@@ -125,7 +125,7 @@ function M.setup(config)
       local gitsigns = require('gitsigns')
       -- Clear gitsigns info for existing buffers.
       for bufnr, _ in pairs(active_bufnrs) do
-        if vim.fn.bufexists(bufnr) then
+        if vim.fn.bufexists(bufnr) == 1 then
           -- luacheck: ignore 122 (setting read-only field b.?.? of global vim)
           vim.b[bufnr][add] = {}
           -- luacheck: ignore 122 (setting read-only field b.?.? of global vim)


### PR DESCRIPTION
The vimscript function `bufexists` will return `0` for `v:false` and `1` for `v:true`,
and `0` is considered true in Lua. This is often an overlooked mistake.