### PR TITLE
Add an extend option to register_sign_spec

### DIFF
--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -756,6 +756,10 @@ register_sign_spec({spec})                 *scrollview.register_sign_spec()*
                 - current_only (boolean): Show only in an current window (the
                   window with the cursor at the time of display). Defaults to
                   `false`.
+                - extend (boolean): Show each sign on all corresponding rows
+                  of the scrollview column, instead of just a single row. This
+                  is relevant when |scrollview_always_show| is on and all lines
+                  and at least one filler line are visible.
                 - group (string): Defaults to `'other'`.
                 - highlight (string): Defaults to `'Pmenu'`.
                 - priority (integer): Defaults to `50`.

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -1528,16 +1528,16 @@ local show_signs = function(winid, sign_winids, bar_winid)
     end
     for _, line in ipairs(lines) do
       if line >= 1 and line <= line_count then
-        local row = binary_search(topline_lookup, line)
-        row = math.min(row, #topline_lookup)
-        if row > 1 and topline_lookup[row] > line then
-          row = row - 1  -- use the preceding line from topline lookup.
+        local row1 = binary_search(topline_lookup, line)
+        row1 = math.min(row1, #topline_lookup)
+        if row1 > 1 and topline_lookup[row1] > line then
+          row1 = row1 - 1  -- use the preceding line from topline lookup.
         end
-        local rows = {row}  -- rows to draw the sign on
+        local rows = {row1}  -- rows to draw the sign on
         -- When extend is set, draw the sign on subsequent rows with the same
         -- topline.
         if sign_spec.extend then
-          while topline_lookup[row] == topline_lookup[rows[#rows] + 1] do
+          while topline_lookup[row1] == topline_lookup[rows[#rows] + 1] do
             table.insert(rows, rows[#rows] + 1)
           end
         end

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -1536,7 +1536,6 @@ local show_signs = function(winid, sign_winids, bar_winid)
         local rows = {row}  -- rows to draw the sign on
         -- When expand is set, draw the sign on subsequent rows with the same
         -- topline.
-        -- TODO: can also check if all lines are on screen.
         if sign_spec.expand then
           while topline_lookup[row] == topline_lookup[rows[#rows] + 1] do
             table.insert(rows, rows[#rows] + 1)

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -1533,21 +1533,30 @@ local show_signs = function(winid, sign_winids, bar_winid)
         if row > 1 and topline_lookup[row] > line then
           row = row - 1  -- use the preceding line from topline lookup.
         end
-        if lookup[row] == nil then
-          lookup[row] = {}
+        local rows = {row}  -- rows to draw the sign on
+        -- When fill is set, draw the sign on subsequent rows with the same
+        -- topline.
+        -- TODO: implement and check for 'fill'
+        while topline_lookup[row] == topline_lookup[rows[#rows] + 1] do
+          table.insert(rows, rows[#rows] + 1)
         end
-        if lookup[row][name] == nil then
-          local properties = {
-            symbol = sign_spec.symbol,
-            highlight = sign_spec.highlight,
-            priority = sign_spec.priority,
-            sign_spec_id = sign_spec.id,
-          }
-          properties.name = name
-          properties.lines = {line}
-          lookup[row][name] = properties
-        else
-          table.insert(lookup[row][name].lines, line)
+        for _, row in ipairs(rows) do
+          if lookup[row] == nil then
+            lookup[row] = {}
+          end
+          if lookup[row][name] == nil then
+            local properties = {
+              symbol = sign_spec.symbol,
+              highlight = sign_spec.highlight,
+              priority = sign_spec.priority,
+              sign_spec_id = sign_spec.id,
+            }
+            properties.name = name
+            properties.lines = {line}
+            lookup[row][name] = properties
+          else
+            table.insert(lookup[row][name].lines, line)
+          end
         end
       end
     end

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -1534,11 +1534,13 @@ local show_signs = function(winid, sign_winids, bar_winid)
           row = row - 1  -- use the preceding line from topline lookup.
         end
         local rows = {row}  -- rows to draw the sign on
-        -- When fill is set, draw the sign on subsequent rows with the same
+        -- When expand is set, draw the sign on subsequent rows with the same
         -- topline.
-        -- TODO: implement and check for 'fill'
-        while topline_lookup[row] == topline_lookup[rows[#rows] + 1] do
-          table.insert(rows, rows[#rows] + 1)
+        -- TODO: can also check if all lines are on screen.
+        if sign_spec.expand then
+          while topline_lookup[row] == topline_lookup[rows[#rows] + 1] do
+            table.insert(rows, rows[#rows] + 1)
+          end
         end
         for _, row in ipairs(rows) do
           if lookup[row] == nil then
@@ -2794,6 +2796,7 @@ local register_sign_spec = function(specification)
   specification.id = id
   local defaults = {
     current_only = false,
+    expand = false,
     group = 'other',
     highlight = 'Pmenu',
     priority = 50,

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -1534,9 +1534,9 @@ local show_signs = function(winid, sign_winids, bar_winid)
           row = row - 1  -- use the preceding line from topline lookup.
         end
         local rows = {row}  -- rows to draw the sign on
-        -- When expand is set, draw the sign on subsequent rows with the same
+        -- When extend is set, draw the sign on subsequent rows with the same
         -- topline.
-        if sign_spec.expand then
+        if sign_spec.extend then
           while topline_lookup[row] == topline_lookup[rows[#rows] + 1] do
             table.insert(rows, rows[#rows] + 1)
           end
@@ -2795,7 +2795,7 @@ local register_sign_spec = function(specification)
   specification.id = id
   local defaults = {
     current_only = false,
-    expand = false,
+    extend = false,
     group = 'other',
     highlight = 'Pmenu',
     priority = 50,

--- a/lua/scrollview/contrib/gitsigns.lua
+++ b/lua/scrollview/contrib/gitsigns.lua
@@ -88,6 +88,7 @@ function M.setup(config)
   local group = 'gitsigns'
 
   local add = scrollview.register_sign_spec({
+    expand = true,
     group = group,
     highlight = config.add_highlight,
     priority = config.add_priority,
@@ -95,6 +96,7 @@ function M.setup(config)
   }).name
 
   local change = scrollview.register_sign_spec({
+    expand = true,
     group = group,
     highlight = config.change_highlight,
     priority = config.change_priority,
@@ -102,6 +104,7 @@ function M.setup(config)
   }).name
 
   local delete = scrollview.register_sign_spec({
+    expand = true,
     group = group,
     highlight = config.delete_highlight,
     priority = config.delete_priority,

--- a/lua/scrollview/contrib/gitsigns.lua
+++ b/lua/scrollview/contrib/gitsigns.lua
@@ -88,7 +88,7 @@ function M.setup(config)
   local group = 'gitsigns'
 
   local add = scrollview.register_sign_spec({
-    expand = true,
+    extend = true,
     group = group,
     highlight = config.add_highlight,
     priority = config.add_priority,
@@ -96,7 +96,7 @@ function M.setup(config)
   }).name
 
   local change = scrollview.register_sign_spec({
-    expand = true,
+    extend = true,
     group = group,
     highlight = config.change_highlight,
     priority = config.change_priority,
@@ -104,7 +104,7 @@ function M.setup(config)
   }).name
 
   local delete = scrollview.register_sign_spec({
-    expand = true,
+    extend = true,
     group = group,
     highlight = config.delete_highlight,
     priority = config.delete_priority,


### PR DESCRIPTION
Add an `extend` option to `register_sign_spec`. When used, signs will each be shown on all corresponding rows of the scrollview column, instead of just a single row. This is relevant when `scrollview_always_show` is on and all lines and at least one filler line are visible.