### PR TITLE
Use vim.on_key for mouse functionality instead of mappings (for nvim>=0.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ scrollview-configuration`).
 ## Requirements
 
 * `nvim>=0.6`
-* Mouse functionality requires mouse support (see `:help 'mouse'`)
+* Mouse functionality requires mouse support (see `:help 'mouse'`) and
+  `nvim>=0.11`
 * Signs require `nvim>=0.9`
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ scrollview-configuration`).
 ## Requirements
 
 * `nvim>=0.6`
-* Mouse functionality requires mouse support (see `:help 'mouse'`) and
-  `nvim>=0.11`
+* Mouse functionality requires mouse support (see `:help 'mouse'`)
 * Signs require `nvim>=0.9`
 
 ## Installation

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -432,42 +432,6 @@ endif
 " * Mappings
 " *************************************************
 
-function! s:SetUpMouseMappings(button, primary) abort
-  if a:button isnot# v:null
-    " Create a mouse mapping only if mappings don't already exist and "!" is
-    " not used at the end of the button. For example, a mapping may already
-    " exist if the user uses swapped buttons from $VIMRUNTIME/pack/dist/opt
-    " /swapmouse/plugin/swapmouse.vim. Handling for that scenario would
-    " require modifications (e.g., possibly by updating the non-initial
-    " feedkeys calls in handle_mouse() to remap keys).
-    let l:force = v:false
-    let l:button = a:button
-    if strcharpart(l:button, strchars(l:button, 1) - 1, 1) ==# '!'
-      let l:force = v:true
-      let l:button =
-            \ strcharpart(l:button, 0, strchars(l:button, 1) - 1)
-    endif
-    " scrollview mouse handling is not supported in select-mode. #140
-    for l:mapmode in ['n', 'x', 'i']
-      execute printf(
-            \   'silent! %snoremap %s <silent> <%smouse>'
-            \   .. ' <cmd>lua require("scrollview").handle_mouse("%s", %s)<cr>',
-            \   l:mapmode,
-            \   l:force ? '' : '<unique>',
-            \   l:button,
-            \   l:button,
-            \   a:primary ? 'true' : 'false',
-            \ )
-    endfor
-  endif
-endfunction
-
-call s:SetUpMouseMappings(g:scrollview_mouse_primary, v:true)
-" :popup doesn't work for nvim<0.8.
-if has('nvim-0.8')
-  call s:SetUpMouseMappings(g:scrollview_mouse_secondary, v:false)
-endif
-
 " Additional <plug> mappings are defined for convenience of creating
 " user-defined mappings that call nvim-scrollview functionality. However,
 " since the usage of <plug> mappings requires recursive map commands, this

--- a/autoload/scrollview.vim
+++ b/autoload/scrollview.vim
@@ -322,6 +322,10 @@ let g:scrollview_ins_mode_buf_lines = 0
 " escaping.
 let g:scrollview_echo_string = v:null
 
+" Keep track of the initial mouse settings. These are only used for nvim<0.11.
+let g:scrollview_init_mouse_primary = g:scrollview_mouse_primary
+let g:scrollview_init_mouse_secondary = g:scrollview_mouse_secondary
+
 " *************************************************
 " * Versioning
 " *************************************************
@@ -431,6 +435,62 @@ endif
 " *************************************************
 " * Mappings
 " *************************************************
+
+function! scrollview#HandleMouseFromMapping(button, is_primary) abort
+  let l:button_repr = nvim_replace_termcodes(
+        \ printf('<%smouse>', a:button), v:true, v:true, v:true)
+  let l:packed = luaeval(
+        \ '{require("scrollview").should_handle_mouse(_A)}', l:button_repr)
+  let l:should_handle = l:packed[0]
+  if l:should_handle
+    let l:data = l:packed[1]
+    call luaeval(
+          \ 'require("scrollview").handle_mouse('
+          \ .. '_A.button, _A.is_primary, _A.props, _A.mousepos)', l:data)
+  else
+    " Process the click as it would ordinarily be processed.
+    call feedkeys(l:button_repr, 'ni')
+  endif
+endfunction
+
+function! s:SetUpMouseMappings(button, primary) abort
+  if a:button isnot# v:null
+    " Create a mouse mapping only if mappings don't already exist and "!" is
+    " not used at the end of the button. For example, a mapping may already
+    " exist if the user uses swapped buttons from $VIMRUNTIME/pack/dist/opt
+    " /swapmouse/plugin/swapmouse.vim. Handling for that scenario would
+    " require modifications (e.g., possibly by updating the non-initial
+    " feedkeys calls in handle_mouse() to remap keys).
+    let l:force = v:false
+    let l:button = a:button
+    if strcharpart(l:button, strchars(l:button, 1) - 1, 1) ==# '!'
+      let l:force = v:true
+      let l:button =
+            \ strcharpart(l:button, 0, strchars(l:button, 1) - 1)
+    endif
+    for l:mapmode in ['n', 'v', 'i']
+      execute printf(
+            \   'silent! %snoremap %s <silent> <%smouse>'
+            \   .. ' <cmd>call scrollview#HandleMouseFromMapping("%s", %s)<cr>',
+            \   l:mapmode,
+            \   l:force ? '' : '<unique>',
+            \   l:button,
+            \   l:button,
+            \   a:primary,
+            \ )
+    endfor
+  endif
+endfunction
+
+" With Neovim 0.11, mouse functionality is handled with vim.on_key, not
+" mappings.
+if !has('nvim-0.11')
+  call s:SetUpMouseMappings(g:scrollview_mouse_primary, v:true)
+  " :popup doesn't work for nvim<0.8.
+  if has('nvim-0.8')
+    call s:SetUpMouseMappings(g:scrollview_mouse_secondary, v:false)
+  endif
+endif
 
 " Additional <plug> mappings are defined for convenience of creating
 " user-defined mappings that call nvim-scrollview functionality. However,

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -20,7 +20,8 @@ signs. The plugin is customizable (see |scrollview-configuration|).
 1. Requirements                            *scrollview-requirements*
 
 * `nvim>=0.6`
-* Scrollbar mouse dragging requires mouse support (see |'mouse'|)
+* Scrollbar mouse functionality requires mouse support (see |'mouse'|) and
+  `nvim>=0.11`
 * Signs require `nvim>=0.9`
 
 ============================================================================
@@ -301,19 +302,15 @@ scrollview_mouse_primary                   *scrollview_mouse_primary*
                        Possible values include `'left'`, `'middle'`, `'right'`,
                        `'x1'`, and `'x2'`. These can be prepended with `'c-'` or
                        `'m-'` for the control-key and alt-key variants (e.g.,
-                       `'c-left'` for control-left). An existing mapping will
-                       not be clobbered, unless `'!'` is added at the end (e.g.,
-                       `'left!'`). Set to `v:null` to disable the functionality.
-                       Defaults to `'left'`. Considered only when the plugin is
-                       loaded.
+                       `'c-left'` for control-left). Set to `v:null` to disable
+                       the functionality. Defaults to `'left'`.
 
 scrollview_mouse_secondary                 *scrollview_mouse_secondary*
                        |String| specifying the button for secondary mouse
                        operations (clicking signs for additional information).
                        See |scrollview_mouse_primary| for the possible values,
-                       including how `'c-'`, `'m-'`, `'!'`, and `v:null` can be
-                       utilized. Defaults to `'right'`. Considered only when the
-                       plugin is loaded.
+                       including how `'c-'`, `'m-'`, and `v:null` can be utilized.
+                       Defaults to `'right'`.
 
                                            *scrollview_on_startup*
 scrollview_on_startup  |Boolean| specifying whether scrollbars are enabled on

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -20,8 +20,7 @@ signs. The plugin is customizable (see |scrollview-configuration|).
 1. Requirements                            *scrollview-requirements*
 
 * `nvim>=0.6`
-* Scrollbar mouse functionality requires mouse support (see |'mouse'|) and
-  `nvim>=0.11`
+* Scrollbar mouse functionality requires mouse support (see |'mouse'|)
 * Signs require `nvim>=0.9`
 
 ============================================================================

--- a/doc/scrollview.txt
+++ b/doc/scrollview.txt
@@ -303,14 +303,18 @@ scrollview_mouse_primary                   *scrollview_mouse_primary*
                        `'x1'`, and `'x2'`. These can be prepended with `'c-'` or
                        `'m-'` for the control-key and alt-key variants (e.g.,
                        `'c-left'` for control-left). Set to `v:null` to disable
-                       the functionality. Defaults to `'left'`.
+                       the functionality. Defaults to `'left'`. For `nvim<0.11`,
+                       an existing mapping will not be clobbered, unless `'!'`
+                       is added at the end (e.g., `'left!'`). For `nvim<0.11`,
+                       the option is considered only when the plugin is loaded.
 
 scrollview_mouse_secondary                 *scrollview_mouse_secondary*
                        |String| specifying the button for secondary mouse
                        operations (clicking signs for additional information).
                        See |scrollview_mouse_primary| for the possible values,
-                       including how `'c-'`, `'m-'`, and `v:null` can be utilized.
-                       Defaults to `'right'`.
+                       including how `'c-'`, `'m-'`, and `v:null` can be utilized,
+                       as well as the behavior specific to `nvim<0.11`. Defaults
+                       to `'right'`.
 
                                            *scrollview_on_startup*
 scrollview_on_startup  |Boolean| specifying whether scrollbars are enabled on

--- a/lua/scrollview.lua
+++ b/lua/scrollview.lua
@@ -2996,8 +2996,8 @@ local handle_mouse = function(button, is_primary, init_props, init_mousepos)
     local scrollbar_offset
     local previous_row
     local idx = 1
-    local str, chars_props = '', {}
-    local str_idx, char, mouse_winid, mouse_row, mouse_col
+    local chars_props = {}
+    local char, mouse_winid, mouse_row
     local props
     -- Computing this prior to the first mouse event could distort the location
     -- since this could be an expensive operation (and the mouse could move).
@@ -3009,7 +3009,6 @@ local handle_mouse = function(button, is_primary, init_props, init_mousepos)
     while true do
       while true do
         if count == 0 then
-          str = mousedown
           chars_props = {{
             char = mousedown,
             str_idx = 1,
@@ -3022,15 +3021,13 @@ local handle_mouse = function(button, is_primary, init_props, init_mousepos)
           idx = idx + 1
           if idx > #chars_props then
             idx = 1
-            str, chars_props = read_input_stream()
+            chars_props = select(2, read_input_stream())
           end
         end
         local char_props = chars_props[idx]
-        str_idx = char_props.str_idx
         char = char_props.char
         mouse_winid = char_props.mouse_winid
         mouse_row = char_props.mouse_row
-        mouse_col = char_props.mouse_col
         -- Break unless it's a mouse drag followed by another mouse drag, so
         -- that the first drag is skipped.
         if mouse_winid == 0
@@ -3064,7 +3061,7 @@ local handle_mouse = function(button, is_primary, init_props, init_mousepos)
           return
         end
         if char == mouseup then
-          if count == 1 then
+          if count == 1 then  -- luacheck: ignore 542 (an empty if branch)
             -- A scrollbar was clicked, but there was no corresponding drag.
           else
             -- A scrollbar was clicked and there was a corresponding drag.


### PR DESCRIPTION
This update adds support for using `vim.on_key` for mouse functionality, instead of mappings, for `nvim>=0.11`. This differs from PR #147 and PR #148, since mappings are still used for `nvim<0.11`.
